### PR TITLE
crd template: defines versions that webhook understands

### DIFF
--- a/crd-template.yaml
+++ b/crd-template.yaml
@@ -8,7 +8,7 @@ spec:
   - name: "v1"
     served: true
     storage: false
-  - name: "v1alpha1"
+  - name: "v2"
     served: true
     storage: true
   conversion:


### PR DESCRIPTION
the webhook image that we use talks in `stable.example.com/v1` and `stable.example.com/v2`